### PR TITLE
chore: add initial chrome 113 browsers

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.zip filter=lfs diff=lfs merge=lfs -text

--- a/chrome/113/chrome-darwin.zip
+++ b/chrome/113/chrome-darwin.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1f56ee95751bcfead8102b8a3a527afe8370b5c314b368bd05dcdbff847d703f
+size 133510544

--- a/chrome/113/chrome-linux.zip
+++ b/chrome/113/chrome-linux.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:50adddc18517d5943865e6be18d21affdd7456d2fb3246d5d706ac4eaa09dd51
+size 173920470

--- a/chrome/113/chrome-win32.zip
+++ b/chrome/113/chrome-win32.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f105c0e5de460ce0512ad7c6d51b15837ba7cc624c17838d947c6e09791b3af5
+size 207929149


### PR DESCRIPTION
As part of our new testing strategy to test older browsers for compatibility with Qwik UI, we need the binaries to be easily accessible so they can be pulled as a pre-test task. This adds binaries for Chrome, Windows, and MacOS